### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ts-check.yml
+++ b/.github/workflows/ts-check.yml
@@ -5,6 +5,9 @@ on:
         branches: ["**"]
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     ts-check:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Jimce-Music/jimce/security/code-scanning/1](https://github.com/Jimce-Music/jimce/security/code-scanning/1)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow or job. Since this job only checks out the repository, installs dependencies, and runs a TypeScript type check, it only needs read access to repository contents.

The best minimal fix without changing functionality is to add a `permissions:` block at the workflow root (affecting all jobs) or under the `ts-check` job. Either is acceptable; placing it at the workflow root is slightly clearer and scales if more jobs are added. Concretely, in `.github/workflows/ts-check.yml`, insert:

```yaml
permissions:
    contents: read
```

between the `on:` block and the `jobs:` block. No additional imports, methods, or definitions are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
