### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/admin/users/getList-users.test.ts
+++ b/tests/integration/routes/api/admin/users/getList-users.test.ts
@@ -7,7 +7,7 @@ import CT_ADMIN_checks from '../../../../components/CT_ADMIN_checks'
 import * as uuid from 'uuid'
 import db from '../../../../../../src/db'
 import { usersTable } from '../../../../../../src/db/schema'
-import { eq } from 'drizzle-orm'
+
 
 describe('GET /api/admin/users/list-users', async () => {
     //! Check for auth


### PR DESCRIPTION
To fix the problem, remove the unused `eq` import so that all imports in the file correspond to actually used symbols. This preserves existing functionality while eliminating the unused code.

Concretely, in `tests/integration/routes/api/admin/users/getList-users.test.ts`, delete the line importing `eq` from `drizzle-orm`. No other changes are needed because `eq` is not referenced anywhere in the file. No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._