### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/auth/getCheck-token.test.ts
+++ b/tests/integration/routes/api/auth/getCheck-token.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../src/fastify'
-import * as z from 'zod'
 import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
 import CT_ADMIN_checks from '../../../components/CT_ADMIN_checks'


### PR DESCRIPTION
To fix the problem, remove the unused import of `zod` so that every import in the file corresponds to actually used symbols. This resolves the CodeQL warning without altering the tests’ behavior.

Concretely, in `tests/integration/routes/api/auth/getCheck-token.test.ts`, delete the line `import * as z from 'zod'`. No other changes are needed because the identifier `z` is never referenced. There are no new functions, methods, or definitions required, and no additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._