### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/auth/getCheck-token.test.ts
+++ b/tests/integration/routes/api/auth/getCheck-token.test.ts
@@ -6,7 +6,6 @@ import getBurnerUser from '../../../getBurnerUser'
 import CT_ADMIN_checks from '../../../components/CT_ADMIN_checks'
 import * as uuid from 'uuid'
 import db from '../../../../../src/db'
-import { usersTable } from '../../../../../src/db/schema'
 import { eq } from 'drizzle-orm'
 
 describe('GET /api/auth/check-token', async () => {


### PR DESCRIPTION
In general, to fix an "unused import" issue, either remove the import or start using the imported symbol meaningfully. Here, the test does not interact directly with the database schema, and adding new references just to "use" the symbol would be artificial and could change test intent, so the best fix is to delete the unused import.

Concretely, in `tests/integration/routes/api/auth/getCheck-token.test.ts`, remove the line importing `usersTable` from `../../../../../src/db/schema`. No other changes are necessary, as nothing in the shown code depends on `usersTable`. This will resolve the CodeQL warning without affecting test behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._