### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/me/getUserinfo.test.ts
+++ b/tests/integration/routes/api/me/getUserinfo.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../src/fastify'
-import * as z from 'zod'
 import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
 import CT_ADMIN_checks from '../../../components/CT_ADMIN_checks'


### PR DESCRIPTION
To fix the problem, remove the unused import of `zod` from this test file. This addresses the CodeQL warning and keeps the code clean without impacting functionality, since `z` is not referenced anywhere.

Concretely, in `tests/integration/routes/api/me/getUserinfo.test.ts`, delete line 3: `import * as z from 'zod'`. No additional code, imports, or definitions are needed, as nothing else in this file depends on `z`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._