### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/auth/putChange-password.test.ts
+++ b/tests/integration/routes/api/auth/putChange-password.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../src/fastify'
-import * as z from 'zod'
 import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
 import * as uuid from 'uuid'


### PR DESCRIPTION
To fix the problem, remove the unused `z` import so that all imports in the file correspond to actually-used symbols. This keeps the test file clean, avoids misleading future readers into thinking `zod`-based validation happens here, and resolves the CodeQL warning without changing test behavior.

Concretely, in `tests/integration/routes/api/auth/putChange-password.test.ts`, delete the line `import * as z from 'zod'`. No other changes are required: the rest of the file does not depend on `z`, and removing the import will not alter runtime semantics.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._