### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,3 @@
-import { timestamp } from 'drizzle-orm/gel-core'
 import {
     integer,
     pgTable,


### PR DESCRIPTION
In general, the right fix for an unused import is to remove it (or start using it if it was intended to be used). Removing it avoids dead code, keeps the file clean, and prevents potential lints or build warnings, without changing runtime behavior.

Here, the simplest and safest fix is to delete the unused `timestamp` import line entirely from `src/db/schema.ts`. No other code in the snippet depends on it, and there are no references to `timestamp`, so functionality will not change. Concretely, in `src/db/schema.ts`, remove line 1 (`import { timestamp } from 'drizzle-orm/gel-core'`). No additional methods, imports, or definitions are needed elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._