### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,12 +1,9 @@
 import { timestamp } from 'drizzle-orm/gel-core'
 import {
-    integer,
     pgTable,
     uniqueIndex,
     uuid,
-    varchar,
     text,
-    serial,
     boolean
 } from 'drizzle-orm/pg-core'
 


### PR DESCRIPTION
In general, unused imports should be removed so that the module only imports the symbols it actually uses. This reduces noise, avoids misleading hints that those types are used, and can provide minor build-time or bundle-size benefits.

The best fix here is to edit `src/db/schema.ts` so that the destructuring import from `drizzle-orm/pg-core` only includes the symbols referenced in the rest of the file. In the provided snippet, only `integer`, `serial`, and `varchar` are unused; `pgTable`, `uniqueIndex`, `uuid`, `text`, and `boolean` are used and must remain. Concretely, update the import on lines 2–11 to drop `integer`, `serial`, and `varchar` from the import list, leaving the rest unchanged. No additional methods, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._