### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -2,7 +2,6 @@
 import Fastify from 'fastify'
 import path from 'path'
 import meta_raw from '../meta.yml'
-import * as z from 'zod'
 import MetaZ from './types/meta.yml.ts'
 const meta = MetaZ.parse(meta_raw)
 


### PR DESCRIPTION
In general, unused imports should be removed to keep the code clean and avoid confusion about intended but unimplemented features. Since the `z` namespace from `'zod'` is not used anywhere in the provided portion of `src/fastify.ts`, the best fix is to delete this import line.

Concretely, in `src/fastify.ts`, remove line 5: `import * as z from 'zod'`. No other code changes are needed, as there are no references to `z`. There is no need to add any new methods, definitions, or imports: the rest of the code uses `MetaZ` for schema parsing and does not depend on `z`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._