### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/fastify.ts
+++ b/src/fastify.ts
@@ -14,7 +14,6 @@ import {
 } from 'fastify-zod-openapi'
 import fastifySwagger from '@fastify/swagger'
 import fastifySwaggerUI from '@fastify/swagger-ui'
-import { version } from 'os'
 
 // Define app / server / fastify 'instance'
 const fastify = Fastify({


### PR DESCRIPTION
In general, unused imports should be removed to keep the codebase clean, avoid confusion, and prevent potential bundling or dead‑code issues. Since `version` from `'os'` is not used anywhere in `src/fastify.ts`, the best fix is to delete that import line entirely.

Concretely, in `src/fastify.ts`, remove line 17:

```ts
import { version } from 'os'
```

No other changes are necessary: no additional imports, methods, or definitions are required, and existing functionality will remain unchanged because the imported symbol was never used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._