### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/music/music.experimental.ts
+++ b/src/music/music.experimental.ts
@@ -1,6 +1,6 @@
 import searchMusic from './metadata/search/searchMusic'
 import { mb } from './musicbrainz'
-import yts, { type SearchResult } from 'yt-search'
+import type { SearchResult } from 'yt-search'
 
 // This is a temporary file to try out the metadata fetching functions
 // console.log(await searchSong('Bella Napoli')) // id: c6d49f0b-951f-407c-b803-c066e4ff3c6c


### PR DESCRIPTION
To fix the problem, remove or adjust the unused import so that there are no symbols imported that are not referenced in active code. We should preserve any parts that are actually used.

In this file, only the default import `yts` is unused; the named type import `SearchResult` could be useful later, but is also unused right now. However, CodeQL specifically complains about `yts`. To minimally change behavior, we will remove just the default import and keep the type import, converting the statement to a type-only import for `SearchResult`. No other changes are needed, as the rest of the file does not reference `yts` in active code.

Concretely, in `src/music/music.experimental.ts`, replace the line:

```ts
import yts, { type SearchResult } from 'yt-search'
```

with:

```ts
import type { SearchResult } from 'yt-search'
```

This removes the unused default import `yts` while keeping the type import in case it is used later in this experimental file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._