### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/admin/users/getList-users.ts
+++ b/src/routes/api/admin/users/getList-users.ts
@@ -11,7 +11,6 @@ import {
 import logger from '../../../../logger'
 import db from '../../../../db'
 import meta from '../../../../meta'
-import config from '../../../../config'
 import { usersTable } from '../../../../db/schema'
 import BadRequestResponseZ from '../../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../../types/InternalServerErrorResponseZ'


### PR DESCRIPTION
To fix the problem in general, remove imports that are not used anywhere in the file, or, if the module is needed only for side effects, convert them to side-effect-only imports (`import 'module'`).

For this specific file, the best fix without changing functionality is to delete the unused `config` import line. Since there are no references to `config` in the file, removing that line will not affect runtime behavior. No other code changes are required. The change is limited to `src/routes/api/admin/users/getList-users.ts`, around line 14 where the `config` import currently exists. No new methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._