### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/auth/getCheck-token.ts
+++ b/src/routes/api/auth/getCheck-token.ts
@@ -9,7 +9,6 @@ import {
     type FastifyZodOpenApiTypeProvider
 } from 'fastify-zod-openapi'
 import logger from '../../../logger'
-import db from '../../../db'
 import meta from '../../../meta'
 import config from '../../../config'
 import BadRequestResponseZ from '../../../types/BadRequestResponseZ'


### PR DESCRIPTION
To fix the problem, remove the unused `db` import from this file. This eliminates the unused symbol, satisfies the CodeQL rule, and does not change runtime behavior assuming `../../../db` was not relied upon for side effects.

Concretely, in `src/routes/api/auth/getCheck-token.ts`, delete the line `import db from '../../../db'`. No other code references `db`, so no additional changes are necessary. No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._