### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/auth/postLogin-basic.ts
+++ b/src/routes/api/auth/postLogin-basic.ts
@@ -17,7 +17,6 @@ import InternalServerErrorResponseZ from '../../../types/InternalServerErrorResp
 import UnauthorizedResponseZ from '../../../types/UnauthorizedResponseZ'
 import {
     encodeJWTPayload,
-    JWTPayloadZ,
     type JWTPayloadT
 } from '../../../types/JWTPayload'
 


### PR DESCRIPTION
To fix this, we should remove the unused symbol `JWTPayloadZ` from the import statement, leaving the other imported members (`encodeJWTPayload`, `JWTPayloadT`) untouched so existing functionality is preserved.

Concretely:
- Edit `src/routes/api/auth/postLogin-basic.ts`.
- In the import from `'../../../types/JWTPayload'`, remove `JWTPayloadZ` from the destructuring list.
- No additional code changes, imports, or definitions are required.

This keeps the file behavior identical while eliminating the unused import and satisfying CodeQL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._