### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/admin/users/deleteUser.test.ts
+++ b/tests/integration/routes/api/admin/users/deleteUser.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../../src/fastify'
-import * as z from 'zod'
 import CT_JWT_checks from '../../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../../getBurnerUser'
 import CT_ADMIN_checks from '../../../../components/CT_ADMIN_checks'


### PR DESCRIPTION
To fix the problem, remove the unused import of `z` from `'zod'`. This eliminates dead code, removes any confusion about unused libraries in this test, and does not affect existing functionality since `z` is not referenced.

Concretely, in `tests/integration/routes/api/admin/users/deleteUser.test.ts`, delete line 3 containing `import * as z from 'zod'`. No other code changes are necessary, and no new methods or imports are required. The rest of the tests will behave identically.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._