### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 // Imports
 import logger from './logger'
 import fastify from './fastify'
-import db, { migrateDB } from './db'
+import { migrateDB } from './db'
 import fs from 'fs'
 import path from 'path'
 import { setupJWT } from './auth/jwt-routes'


### PR DESCRIPTION
In general, to fix an unused-import issue, remove the unused identifier from the import statement (or, if the module is truly unused, remove the import entirely). This keeps the codebase clean, avoids confusion about what is actually used, and can slightly improve startup time and bundling.

Here, the best fix is to remove the unused default import `db` from `./db` while retaining the named import `migrateDB`, which is used on line 26. This means editing `src/index.ts` at line 5 to change `import db, { migrateDB } from './db'` to `import { migrateDB } from './db'`. No additional methods, definitions, or imports are required, and functionality remains the same because the module `./db` is still imported for `migrateDB`, preserving any top-level side effects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._