### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/music/music.experimental.ts
+++ b/src/music/music.experimental.ts
@@ -1,5 +1,4 @@
 import searchMusic from './metadata/search/searchMusic'
-import { mb } from './musicbrainz'
 import type { SearchResult } from 'yt-search'
 
 // This is a temporary file to try out the metadata fetching functions


### PR DESCRIPTION
In general, to fix unused import issues, remove the unused symbol from the import statement or delete the entire import if nothing from that module is used. This keeps the codebase clean and avoids unnecessary module loading.

For this specific file, `src/music/music.experimental.ts`, the symbol `mb` imported from `'./musicbrainz'` is not used anywhere in active code; only commented examples refer to it. The safest and smallest functional change is to delete the entire second line:

```ts
import { mb } from './musicbrainz'
```

No other changes are needed because nothing in the active code depends on `mb`. If developers later want to use `mb` again for manual experiments, they can re-add the import when they uncomment the example lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._