### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/admin/users/deleteUser.ts
+++ b/src/routes/api/admin/users/deleteUser.ts
@@ -10,7 +10,7 @@ import {
 } from 'fastify-zod-openapi'
 import logger from '../../../../logger'
 import db from '../../../../db'
-import meta from '../../../../meta'
+import '../../../../meta'
 import config from '../../../../config'
 import BadRequestResponseZ from '../../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../../types/InternalServerErrorResponseZ'


### PR DESCRIPTION
To fix the problem, remove the unused `meta` import (or, if it is genuinely needed only for side effects, convert it to a side-effect-only import). Since we must avoid changing functionality, the best minimal fix that keeps any potential side effects is to convert the unused default import into a side-effect import: change `import meta from '../../../../meta'` to `import '../../../../meta'`. This preserves module execution while eliminating the unused binding.

Concretely, in `src/routes/api/admin/users/deleteUser.ts`, at line 13, replace the current import statement `import meta from '../../../../meta'` with `import '../../../../meta'`. No other code changes or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._