### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/admin/users/getList-users.ts
+++ b/src/routes/api/admin/users/getList-users.ts
@@ -10,7 +10,6 @@ import {
 } from 'fastify-zod-openapi'
 import logger from '../../../../logger'
 import db from '../../../../db'
-import meta from '../../../../meta'
 import { usersTable } from '../../../../db/schema'
 import BadRequestResponseZ from '../../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../../types/InternalServerErrorResponseZ'


### PR DESCRIPTION
In general, to fix an unused import warning you either remove the import or, if the module is needed for side effects only, switch to a side-effect import (`import 'module'`) without binding it to a variable. This keeps required behavior while avoiding a falsely “unused” binding.

Here, the best fix without changing functionality is to delete the unused `meta` import, because nothing in the file references `meta`, and there is no explicit sign that the module is needed for side effects. We only adjust the specific import line in `src/routes/api/admin/users/getList-users.ts` and leave the rest untouched. No new methods or imports are needed.

Concretely:
- In `src/routes/api/admin/users/getList-users.ts`, remove the line `import meta from '../../../../meta'`.
- No other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._