### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/admin/users/putCreateOrChange.ts
+++ b/src/routes/api/admin/users/putCreateOrChange.ts
@@ -10,7 +10,6 @@ import {
 } from 'fastify-zod-openapi'
 import logger from '../../../../logger'
 import db from '../../../../db'
-import meta from '../../../../meta'
 import config from '../../../../config'
 import BadRequestResponseZ from '../../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../../types/InternalServerErrorResponseZ'


### PR DESCRIPTION
In general, unused imports should be removed to keep the code clean, avoid confusion, and prevent potential build or lint errors. If the imported module is only needed for its side effects, it should be imported without assigning it to a variable or name.

For this specific case, the best fix without changing functionality is to remove the unused `meta` import entirely. If, in reality, the module is required for side effects (not evident from the snippet), the import should instead be changed to a side-effect-only import (`import '../../../../meta'`). However, since there is no indication of such a need and other code in the file does not reference `meta`, the minimal and safest fix is to delete the line `import meta from '../../../../meta'`.

Concretely, edit `src/routes/api/admin/users/putCreateOrChange.ts` and remove line 13 containing the `meta` import, leaving all other imports and logic unchanged. No additional methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._