### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/auth/postLogin-basic.ts
+++ b/src/routes/api/auth/postLogin-basic.ts
@@ -10,7 +10,6 @@ import {
 } from 'fastify-zod-openapi'
 import logger from '../../../logger'
 import db from '../../../db'
-import meta from '../../../meta'
 import config from '../../../config'
 import BadRequestResponseZ from '../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../types/InternalServerErrorResponseZ'


### PR DESCRIPTION
To fix the problem, remove the unused `meta` import (or, if the module is needed only for side effects, convert it to a bare import). This eliminates dead code, avoids confusion, and addresses the CodeQL warning without changing runtime behavior.

The best minimal change that preserves existing functionality is to delete the `import meta from '../../../meta'` line. If `../../../meta` is required for side effects, the codebase should already be handling that elsewhere; in any case, the bound identifier is not needed. No additional methods, imports, or definitions are required, and no other lines in this file need to change.

Concretely, in `src/routes/api/auth/postLogin-basic.ts`, remove line 13 that currently reads `import meta from '../../../meta'`. All other imports remain as they are.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._