### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/auth/getCheck-token.ts
+++ b/src/routes/api/auth/getCheck-token.ts
@@ -9,7 +9,6 @@ import {
     type FastifyZodOpenApiTypeProvider
 } from 'fastify-zod-openapi'
 import logger from '../../../logger'
-import meta from '../../../meta'
 import config from '../../../config'
 import BadRequestResponseZ from '../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../types/InternalServerErrorResponseZ'


### PR DESCRIPTION
To fix the problem, remove the unused `meta` import from this file. This eliminates dead code, keeps the module’s dependencies accurate, and satisfies CodeQL’s unused-import check.

Concretely, in `src/routes/api/auth/getCheck-token.ts`, delete the line:

```ts
import meta from '../../../meta'
```

No other code changes are needed: `meta` is not referenced in the handler, schema, or elsewhere in the snippet, so removing the import will not affect runtime behavior. No additional methods, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._