### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/auth/putChange-password.ts
+++ b/src/routes/api/auth/putChange-password.ts
@@ -10,7 +10,7 @@ import {
 } from 'fastify-zod-openapi'
 import logger from '../../../logger'
 import db from '../../../db'
-import meta from '../../../meta'
+import '../../../meta'
 import BadRequestResponseZ from '../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../types/InternalServerErrorResponseZ'
 import UnauthorizedResponseZ from '../../../types/UnauthorizedResponseZ'


### PR DESCRIPTION
In general, to fix an unused import, either remove the import entirely or, if the module is needed only for its side effects, convert it to a side‑effect‑only import without a binding. This removes the unused identifier while preserving any required runtime behavior.

For this specific file (`src/routes/api/auth/putChange-password.ts`), the best fix that does not change existing functionality is:

- If the `../../../meta` module is not needed for side effects, delete the import line.
- If `../../../meta` is intended solely for side effects (common with configuration or telemetry modules), change `import meta from '../../../meta'` to `import '../../../meta'`.

Because the instructions say not to assume behavior outside the shown snippets, the safest non‑breaking change is to keep the import but remove the unused binding, turning it into a side‑effect import. Concretely, on line 13, replace:
- `import meta from '../../../meta'`
with:
- `import '../../../meta'`

No new methods or definitions are required; we only adjust this one import. No additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._