### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/components/CT_JWT_checks.ts
+++ b/tests/integration/components/CT_JWT_checks.ts
@@ -1,5 +1,4 @@
 import { expect, test, describe } from 'bun:test'
-import * as z from 'zod'
 import fastify from '../../../src/fastify'
 import getBurnerUser from '../getBurnerUser'
 


### PR DESCRIPTION
In general, unused imports should be removed to keep the codebase clean and avoid confusion about dependencies. For this specific file, the best fix is simply to delete the unused `zod` import line while leaving the rest of the file unchanged.

Concretely:
- In `tests/integration/components/CT_JWT_checks.ts`, remove line 2: `import * as z from 'zod'`.
- No other code depends on `z`, so no further changes are needed.
- No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._