### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/me/getUserinfo.test.ts
+++ b/tests/integration/routes/api/me/getUserinfo.test.ts
@@ -5,7 +5,6 @@ import getBurnerUser from '../../../getBurnerUser'
 import * as uuid from 'uuid'
 import db from '../../../../../src/db'
 import { usersTable } from '../../../../../src/db/schema'
-import { eq } from 'drizzle-orm'
 
 describe('GET /api/me/userinfo', async () => {
     //! Check for auth


### PR DESCRIPTION
To fix the problem, we should remove the unused import for `eq` from `drizzle-orm` in this test file. In general, unused imports should be deleted unless they are intentionally present for side effects (which is not the case for a named function like `eq`). This keeps the code clean and avoids misleading readers and tools.

Concretely, in `tests/integration/routes/api/me/getUserinfo.test.ts`, delete the line `import { eq } from 'drizzle-orm'`. No other changes are needed because nothing in the file references `eq`. We do not need additional methods, imports, or definitions; we simply remove the unused import line and leave the rest of the file intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._