### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/admin/users/putCreateOrChange.ts
+++ b/src/routes/api/admin/users/putCreateOrChange.ts
@@ -10,7 +10,6 @@ import {
 } from 'fastify-zod-openapi'
 import logger from '../../../../logger'
 import db from '../../../../db'
-import config from '../../../../config'
 import BadRequestResponseZ from '../../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../../types/InternalServerErrorResponseZ'
 import UnauthorizedResponseZ from '../../../../types/UnauthorizedResponseZ'


### PR DESCRIPTION
To fix the problem, remove the unused `config` import so that the file no longer declares a symbol it doesn’t use. This eliminates dead code, avoids confusion about configuration being involved when it is not, and silences the CodeQL warning.

Concretely, in `src/routes/api/admin/users/putCreateOrChange.ts`, delete the line:

```ts
import config from '../../../../config'
```

No other changes are required: no additional imports, functions, or definitions are needed, and existing functionality will remain unchanged because `config` was never referenced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._