### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/auth/postLogin-basic.ts
+++ b/src/routes/api/auth/postLogin-basic.ts
@@ -10,7 +10,6 @@ import {
 } from 'fastify-zod-openapi'
 import logger from '../../../logger'
 import db from '../../../db'
-import config from '../../../config'
 import BadRequestResponseZ from '../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../types/InternalServerErrorResponseZ'
 import UnauthorizedResponseZ from '../../../types/UnauthorizedResponseZ'


### PR DESCRIPTION
To fix an unused import, remove it if the imported symbol is not actually used, or use it if there was an intended usage that was accidentally omitted. Here, there is no evidence in the route implementation that `config` should be used (e.g., to gate basic auth or read settings), and adding speculative uses would change behavior. The safest fix that doesn’t alter existing behavior is simply to delete the unused import line.

Concretely, in `src/routes/api/auth/postLogin-basic.ts`, delete the line:

- `import config from '../../../config'`

This requires no further code changes, since nothing depends on `config` in the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._