### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/components/CT_ADMIN_checks.ts
+++ b/tests/integration/components/CT_ADMIN_checks.ts
@@ -1,5 +1,4 @@
 import { expect } from 'bun:test'
-import * as z from 'zod'
 import fastify from '../../../src/fastify'
 import getBurnerUser from '../getBurnerUser'
 


### PR DESCRIPTION
To fix the problem, we should remove the unused import of `z` from `'zod'`. This eliminates dead code, makes the file clearer, and satisfies the static analysis rule about unused imports.

Concretely, in `tests/integration/components/CT_ADMIN_checks.ts`, delete the line `import * as z from 'zod'`. No other changes are required because nothing in the file depends on `z`. We should not add any extra logic or new imports, as the existing functionality of the test helper already works without `z` and we are only cleaning up an unused symbol.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._