### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/components/CT_JWT_checks.ts
+++ b/tests/integration/components/CT_JWT_checks.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from 'bun:test'
+import { expect } from 'bun:test'
 import fastify from '../../../src/fastify'
 import getBurnerUser from '../getBurnerUser'
 


### PR DESCRIPTION
To fix the issue, remove the unused named imports `test` and `describe` from the `bun:test` import, leaving only `expect`, which is actually used. This keeps behavior unchanged, since those identifiers are never referenced, and will eliminate the CodeQL warning about unused imports.

Concretely, in `tests/integration/components/CT_JWT_checks.ts`, update the first import line to import only `expect` from `bun:test`. No other code changes or new imports are needed, and no behavior will change because `test` and `describe` were not used anywhere in the provided file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._