### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/me/getUserinfo.test.ts
+++ b/tests/integration/routes/api/me/getUserinfo.test.ts
@@ -3,7 +3,6 @@ import fastify from '../../../../../src/fastify'
 import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
 import db from '../../../../../src/db'
-import { usersTable } from '../../../../../src/db/schema'
 
 describe('GET /api/me/userinfo', async () => {
     //! Check for auth


### PR DESCRIPTION
In general, unused imports should be removed to keep the code clean and avoid confusion. If the imported symbol is genuinely needed, the correct fix would be to use it; otherwise, the safest fix is to delete the unused import line.

For this specific file, `usersTable` is never referenced, and the test only verifies API behavior via HTTP injection. The best fix without changing functionality is to remove the named import of `usersTable` from `../../../../../src/db/schema`. No other code changes are required. Concretely, in `tests/integration/routes/api/me/getUserinfo.test.ts`, delete the line `import { usersTable } from '../../../../../src/db/schema'`. There are no new methods, imports, or definitions needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._