### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/admin/users/putCreateOrChange.test.ts
+++ b/tests/integration/routes/api/admin/users/putCreateOrChange.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../../src/fastify'
-import * as z from 'zod'
 import CT_JWT_checks from '../../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../../getBurnerUser'
 import CT_ADMIN_checks from '../../../../components/CT_ADMIN_checks'


### PR DESCRIPTION
To fix the problem, remove the unused import of `zod` so that all imported symbols in this test file are actually used. This avoids confusion for maintainers, slightly reduces load time, and satisfies the CodeQL rule.

The single best way to fix this without changing existing functionality is to delete the line `import * as z from 'zod'` from `tests/integration/routes/api/admin/users/putCreateOrChange.test.ts`. No other code references `z`, so no further edits are needed. No new methods, imports, or definitions are required.

Concretely:
- In `tests/integration/routes/api/admin/users/putCreateOrChange.test.ts`, remove line 3 containing the `zod` import.
- Leave all other imports and code as-is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._