### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/auth/getCheck-token.test.ts
+++ b/tests/integration/routes/api/auth/getCheck-token.test.ts
@@ -4,7 +4,6 @@ import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
 import * as uuid from 'uuid'
 import db from '../../../../../src/db'
-import { eq } from 'drizzle-orm'
 
 describe('GET /api/auth/check-token', async () => {
     //! Check for auth


### PR DESCRIPTION
In general, unused imports should be removed to avoid confusion, reduce bundle size, and keep tests clear. When a symbol is imported but not referenced, it is almost always safe to delete the import line (or remove that symbol from a multi-symbol import) as long as the module does not rely on import side effects for that symbol.

For this specific case, the best fix is to remove the unused `eq` import from `drizzle-orm` on line 7 of `tests/integration/routes/api/auth/getCheck-token.test.ts`. No other code changes are needed: the test only uses `expect`, `test`, `describe`, `fastify`, `CT_JWT_checks`, `getBurnerUser`, `uuid`, and `db`, and does not refer to `eq`. Removing the import does not change any functionality because `eq` is not used for side effects. Implementation-wise, simply delete the line `import { eq } from 'drizzle-orm'` and leave the rest of the file intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._