### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/auth/getCheck-token.test.ts
+++ b/tests/integration/routes/api/auth/getCheck-token.test.ts
@@ -2,7 +2,6 @@ import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../src/fastify'
 import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
-import * as uuid from 'uuid'
 import db from '../../../../../src/db'
 import { eq } from 'drizzle-orm'
 


### PR DESCRIPTION
In general, to fix unused import issues, remove the import statements for identifiers that are not referenced in the file. This eliminates noise, avoids misleading future readers into thinking a dependency is required, and satisfies static analysis rules.

For this specific case, the best fix is simply to delete the unused `uuid` import from `tests/integration/routes/api/auth/getCheck-token.test.ts`. No other code needs to change because the `uuid` symbol is never used in this file. Functionality remains identical: the tests rely only on the other imports already present. No new methods or definitions are needed, and no additional imports are required.

Concretely:
- In `tests/integration/routes/api/auth/getCheck-token.test.ts`, remove line 5: `import * as uuid from 'uuid'`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._