### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/routes/api/admin/users/deleteUser.ts
+++ b/src/routes/api/admin/users/deleteUser.ts
@@ -11,7 +11,6 @@ import {
 import logger from '../../../../logger'
 import db from '../../../../db'
 import '../../../../meta'
-import config from '../../../../config'
 import BadRequestResponseZ from '../../../../types/BadRequestResponseZ'
 import InternalServerErrorResponseZ from '../../../../types/InternalServerErrorResponseZ'
 import UnauthorizedResponseZ from '../../../../types/UnauthorizedResponseZ'


### PR DESCRIPTION
To fix the problem, remove the unused `config` import from this file so that all imports correspond to actually used symbols. This keeps the code clean, avoids potential linting/CodeQL warnings, and does not affect functionality.

Concretely, in `src/routes/api/admin/users/deleteUser.ts`, delete the line:

```ts
import config from '../../../../config'
```

No other code changes are necessary, and no additional methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._