### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/admin/users/getList-users.test.ts
+++ b/tests/integration/routes/api/admin/users/getList-users.test.ts
@@ -1,6 +1,5 @@
 import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../../src/fastify'
-import * as z from 'zod'
 import CT_JWT_checks from '../../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../../getBurnerUser'
 import CT_ADMIN_checks from '../../../../components/CT_ADMIN_checks'


### PR DESCRIPTION
In general, the right fix for an unused import is to delete it unless it reveals a missing use that should be added instead. Here, the tests only perform HTTP calls and length comparisons and do not use `zod` schemas, so the safest, minimal change is to remove the unused `z` import.

Concretely, in `tests/integration/routes/api/admin/users/getList-users.test.ts`, delete the line `import * as z from 'zod'`. No other lines depend on `z`, and no additional imports or definitions are needed. This will resolve the CodeQL warning without affecting the existing tests’ behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._