### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/me/getUserinfo.test.ts
+++ b/tests/integration/routes/api/me/getUserinfo.test.ts
@@ -2,7 +2,6 @@ import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../src/fastify'
 import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
-import db from '../../../../../src/db'
 
 describe('GET /api/me/userinfo', async () => {
     //! Check for auth


### PR DESCRIPTION
In general, unused imports should be removed to avoid dead code, confusion, and potential maintenance issues. Since `db` is not referenced in this test file, the safest and smallest change is to delete the unused import line.

The best fix here is to remove the line `import db from '../../../../../src/db'` from `tests/integration/routes/api/me/getUserinfo.test.ts`. This does not affect any other logic: the tests rely only on `expect`, `test`, `describe`, `fastify`, `CT_JWT_checks`, and `getBurnerUser`. No other changes are required.

Concretely:
- Edit `tests/integration/routes/api/me/getUserinfo.test.ts`.
- Delete line 5 containing the `db` import.
- Leave all other imports and test code unchanged.

No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._