### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/admin/users/getList-users.test.ts
+++ b/tests/integration/routes/api/admin/users/getList-users.test.ts
@@ -4,7 +4,6 @@ import * as z from 'zod'
 import CT_JWT_checks from '../../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../../getBurnerUser'
 import CT_ADMIN_checks from '../../../../components/CT_ADMIN_checks'
-import * as uuid from 'uuid'
 import db from '../../../../../../src/db'
 import { usersTable } from '../../../../../../src/db/schema'
 


### PR DESCRIPTION
To fix the problem, the unused import should be removed from the test file. This eliminates dead code, avoids confusion, and satisfies the static analysis rule without changing functionality.

Concretely, in `tests/integration/routes/api/admin/users/getList-users.test.ts`, delete the line `import * as uuid from 'uuid'`. No other code changes are required because nothing in this file references `uuid`. We do not need any new methods, imports, or definitions; we are only removing the unused import line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._