### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/routes/api/auth/getCheck-token.test.ts
+++ b/tests/integration/routes/api/auth/getCheck-token.test.ts
@@ -2,7 +2,6 @@ import { expect, test, describe } from 'bun:test'
 import fastify from '../../../../../src/fastify'
 import CT_JWT_checks from '../../../components/CT_JWT_checks'
 import getBurnerUser from '../../../getBurnerUser'
-import db from '../../../../../src/db'
 
 describe('GET /api/auth/check-token', async () => {
     //! Check for auth


### PR DESCRIPTION
In general, the correct fix for an unused import is to remove it if it is not needed, or to document/use it explicitly if it is required for side effects. Here, the simplest and safest change that does not alter functionality is to delete the `db` import line, because nothing in the test body references `db`. If the `db` module were needed for side effects, we would keep a bare import (e.g., `import '../../../../../src/db'`), but there is no evidence of such a requirement, so we should eliminate the import entirely.

Concretely, in `tests/integration/routes/api/auth/getCheck-token.test.ts`, remove line 5: `import db from '../../../../../src/db'`. No other changes, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._